### PR TITLE
Update version number for mkdocs-material package

### DIFF
--- a/automatic/mkdocs-material/mkdocs-material.nuspec
+++ b/automatic/mkdocs-material/mkdocs-material.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>mkdocs-material</id>
     <title>MkDocs Material Theme</title>
-    <version>0.0.0</version>
+    <version>0.2.4</version>
     <authors>Martin Donath</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>http://squidfunk.github.io/mkdocs-material/</projectUrl>

--- a/automatic/mkdocs-material/tools/ChocolateyInstall.ps1
+++ b/automatic/mkdocs-material/tools/ChocolateyInstall.ps1
@@ -1,5 +1,5 @@
 Update-SessionEnvironment
 
-$version = '0.0.0'
+$version = '0.2.4'
 
 python -m pip install mkdocs-material==$version


### PR DESCRIPTION
Update version number for mkdocs-material package, since AU failed to do so during update