### PR TITLE
Use commit hashes for linking to icons

### DIFF
--- a/automatic/bower/bower.nuspec
+++ b/automatic/bower/bower.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>http://bower.io/</projectUrl>
     <projectSourceUrl>https://github.com/bower/bower/</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/automatic/bower</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/Bower.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/9895f43909b7d6ff6978eda40e30e03fdcf84e29/icons/Bower.png</iconUrl>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <docsUrl>https://bower.io/</docsUrl>
     <bugTrackerUrl>https://github.com/bower/bower/issues</bugTrackerUrl>

--- a/automatic/gulp-cli/gulp-cli.nuspec
+++ b/automatic/gulp-cli/gulp-cli.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/gulpjs/gulp-cli</projectUrl>
     <projectSourceUrl>https://github.com/gulpjs/gulp-cli</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/automatic/gulp-cli</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/gulp-cli.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/d632188d69029ca9ac53b8322de3f2641be1e59e/icons/gulp-cli.png</iconUrl>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <docsUrl>https://github.com/gulpjs/gulp-cli/tree/master/docs</docsUrl>
     <bugTrackerUrl>https://github.com/gulpjs/gulp-cli/issues</bugTrackerUrl>

--- a/automatic/mkdocs-material/mkdocs-material.nuspec
+++ b/automatic/mkdocs-material/mkdocs-material.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>http://squidfunk.github.io/mkdocs-material/</projectUrl>
     <projectSourceUrl>https://github.com/squidfunk/mkdocs-material</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/automatic/mkdocs-material</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/MkDocsMaterial.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/98fa658da12bb835928f7ce9ac7a4ce758e26831/icons/MkDocsMaterial.png</iconUrl>
     <licenseUrl>http://squidfunk.github.io/mkdocs-material/license/</licenseUrl>
     <docsUrl>http://squidfunk.github.io/mkdocs-material/</docsUrl>
     <bugTrackerUrl>https://github.com/squidfunk/mkdocs-material/issues</bugTrackerUrl>

--- a/automatic/mkdocs/mkdocs.nuspec
+++ b/automatic/mkdocs/mkdocs.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>http://www.mkdocs.org</projectUrl>
     <projectSourceUrl>https://github.com/mkdocs/mkdocs/</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/automatic/mkdocs</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/MkDocs.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/6b99e941a304b78c4406e610a34a31503d5aff28/icons/MkDocs.png</iconUrl>
     <licenseUrl>https://github.com/mkdocs/mkdocs/blob/master/LICENSE</licenseUrl>
     <docsUrl>http://www.mkdocs.org</docsUrl>
     <bugTrackerUrl>https://github.com/mkdocs/mkdocs/issues</bugTrackerUrl>

--- a/manual/vscode-cake/vscode-cake.nuspec
+++ b/manual/vscode-cake/vscode-cake.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=cake-build.cake-vscode</projectUrl>
     <projectSourceUrl>https://github.com/cake-build/cake-vscode</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/manual/vscode-cake</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/vscode-cake.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/19e7388f56f2faf2e2b7a270984d51e93ff8a1cb/icons/vscode-cake.png</iconUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=cake-build.cake-vscode</docsUrl>
     <bugTrackerUrl>https://github.com/cake-build/cake-vscode/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/manual/vscode-eslint/vscode-eslint.nuspec
+++ b/manual/vscode-eslint/vscode-eslint.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint</projectUrl>
     <projectSourceUrl>https://github.com/Microsoft/vscode-eslint</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/manual/vscode-eslint</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/vscode-eslint.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/d8c9bacbea3fd9ad9824780608620b218b47e683/icons/vscode-eslint.png</iconUrl>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint</docsUrl>
     <bugTrackerUrl>https://github.com/Microsoft/vscode-eslint/issues</bugTrackerUrl>

--- a/manual/vscode-markdownlint/vscode-markdownlint.nuspec
+++ b/manual/vscode-markdownlint/vscode-markdownlint.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint</projectUrl>
     <projectSourceUrl>https://github.com/DavidAnson/vscode-markdownlint</projectSourceUrl>
     <packageSourceUrl>https://github.com/BBTSoftwareAG/chocolatey-packages/tree/master/manual/vscode-markdownlint</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/master/icons/vscode-markdownlint.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/BBTSoftwareAG/chocolatey-packages/4a055e434da1035a66c821c68869de8ea06bdd2f/icons/vscode-markdownlint.png</iconUrl>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint</docsUrl>
     <bugTrackerUrl>https://github.com/DavidAnson/vscode-markdownlint/issues</bugTrackerUrl>


### PR DESCRIPTION
Use commit hashes for linking to icons. as per [Chocolatey Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/wiki/Contributing-guidelines#152-use-commit-hash).